### PR TITLE
Get with body

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,7 +99,7 @@ All the beauty of map reduce now with elasticsearch queries.
 
 | Field | Description |
 |---|---|
-| url | The url for your elasticsearch instance in the format protocol://url:port, i.e. http://localhost:9300 | 
+| url | The url for your elasticsearch instance in the format protocol://url:port, i.e. http://localhost:9300. Supports query through kibana as well, i.e. https://kibana:kibana@yourkibana.net/elasticsearch | 
 | index | The ElasticSearch Index you want to query | 
 | query | Your search query | 
 | transform | A function that applies a specified function on your queries result. See below for more details |

--- a/src/services/ElasticQueryable.ts
+++ b/src/services/ElasticQueryable.ts
@@ -8,7 +8,13 @@ var ProgressBar = require('ascii-progress');
 export class ElasticQueryExecutor {
     public execute(url: string, json: Object) {
         return new Promise((resolve, reject) => {
-            request({ method: "POST", url, json }, (err, result) => {
+            const uri = require("url").parse(url);
+            let auth = null;
+            if (uri.auth) {
+                auth = uri.auth;
+                url = url.replace(uri.auth + "@", "");
+            }
+            request({ method: "GET", url, auth, json }, (err, result) => {
                 if (err || result.statusCode > 399) return reject(err || new Error(result.body.error));
                 else resolve(result.body);
             });


### PR DESCRIPTION
Changed to search using GET with body to be able to support more of kibana's elasticsearch endpoint thingies (i.e. POST may fail with missing xsfr token due to missing token)